### PR TITLE
Add option to use text-based editor decorations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,37 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
 {
-    "version": "0.1.0",
-    "configurations": [
-        {
-            "name": "Launch Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            "preLaunchTask": "npm"
-        },
-        {
-            "name": "Launch Tests",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-            "preLaunchTask": "npm"
-        }
-    ]
+	"version": "0.1.0",
+	"configurations": [
+		{
+			"name": "Launch Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/src/**/*.js"
+			],
+			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}",
+				"--extensionTestsPath=${workspaceRoot}/out/test"
+			],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/test/**/*.js"
+			],
+			"preLaunchTask": "npm"
+		}
+	]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/metaseed/metago.svg)](https://isitmaintained.com/project/metaseed/metago "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/metaseed/metago.svg)](https://isitmaintained.com/project/metaseed/metago "Percentage of issues still open")
 
+# Fork
+This is a fork of the original, that fixes decorations disappearing in VSCode version 1.40. Here until activity on the original repo resumes.
+
+---
+
 ## Features
 MetaGo provides fast cursor movement/selection for keyboard focused users:
 * go to any character on screen with 3(most cases) or 4 times key press.
@@ -27,16 +32,16 @@ MetaGo provides fast cursor movement/selection for keyboard focused users:
 ### go to any character on screen
 1. type <kbd>Alt</kbd>+<kbd>;</kbd> to tell I want to *go* somewhere.
 2. type the character(stands for location) on screen, metaGo will show you some codes encoded with character.
-3. type the code characters, you will *go* to that location. 
+3. type the code characters, you will *go* to that location.
 
 > at any time press <kbd>ESC</kbd> to cancel
 
 
-> the <kbd>Alt</kbd>+<kbd>;</kbd> command will trigger the metaGo.goto command, the cursor will be placed after the target character; 
+> the <kbd>Alt</kbd>+<kbd>;</kbd> command will trigger the metaGo.goto command, the cursor will be placed after the target character;
 metaGo.gotoBefore(default: <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>;</kbd>) and metaGo.gotoInteli commands are also provided.
 metaGo.gotoInteli intelligently set cursor position after navigation:
 > if the target is at the begin of the word, the cursor will be set before target character, otherwise after it;
-> The 'word' is defined as a group of all alphanumeric or punctuation characters. 
+> The 'word' is defined as a group of all alphanumeric or punctuation characters.
 > MetaGo also provide commands that set cursor before/after the character after navigation, you can config the shortcut by yourself.
 
 > * type <kbd>Alt</kbd>+<kbd>;</kbd> and then press <kbd>Enter</kbd> to directly go to the one above;
@@ -97,7 +102,7 @@ If you have any requirements or dependencies, add a section describing those and
 
 ## Default Shortcut Settings
 
-            { 
+            {
                 "command": "metaGo.input.cancel",
                 "key": "escape",
                 "when": "editorTextFocus && metaGoInput"

--- a/package.json
+++ b/package.json
@@ -1,323 +1,328 @@
 {
-    "name": "metago",
-    "displayName": "MetaGo",
-    "description": "vscode cursor move and select; jump, navigation, goto, acejump",
-    "icon": "images/metago.png",
-    "version": "2.11.0",
-    "publisher": "metaseed",
-    "homepage": "https://github.com/metaseed/metaGo",
-    "license": "MIT",
-    "keywords": [
-        "jumpy",
-        "goto",
-        "navigation",
-        "EasyMotion",
-        "acejump, metaGo, center screen, focus screen, space jumper, shortcut"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/metaseed/metaGo.git"
-    },
-    "bugs": {
-        "url": "https://github.com/metaseed/metaGo/issues",
-        "email": "metaseed@gmail.com"
-    },
-    "engines": {
-        "vscode": "^1.8.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "metaGo.goto",
-                "title": "metaGo: GoTo"
-            },
-            {
-                "command": "metaGo.selection",
-                "title": "metaGo: selection"
-            },
-            {
-                "command": "metaGo.gotoAfter",
-                "title": "metaGo: GoToAfter"
-            },
-            {
-                "command": "metaGo.gotoBefore",
-                "title": "metaGo: gotoBefore"
-            },
-            {
-                "command": "metaGo.selectLineUp",
-                "title": "metaGo: selectLineUp"
-            },
-            {
-                "command": "metaGo.selectLineDown",
-                "title": "metaGo: selectLineDown"
-            },
-            {
-                "command": "metaGo.currentLineToCenter",
-                "title": "metaGo: currentLineToCenter"
-            },
-            {
-                "command": "metaGo.currentLineToTop",
-                "title": "metaGo: currentLineToTop"
-            },
-            {
-                "command": "metaGo.spaceBlockMoveUp",
-                "title": "metaGo: spaceBlockMoveUp"
-            },
-            {
-                "command": "metaGo.spaceBlockSelectUp",
-                "title": "metaGo: spaceBlockSelectUp"
-            },
-            {
-                "command": "metaGo.spaceBlockMoveDown",
-                "title": "metaGo: spaceBlockMoveDown"
-            },
-            {
-                "command": "metaGo.spaceBlockSelectDown",
-                "title": "metaGo: spaceBlockSelectDown"
-            },
-            {
-                "command": "metaGo.bookmark.toggle",
-                "title": "metaGo: bookmark: Toggle"
-            },
-            {
-                "command": "metaGo.bookmark.view",
-                "title": "metaGo: bookmark: View"
-            },
-            {
-                "command": "metaGo.bookmark.clear",
-                "title": "metaGo: bookmark: Clear"
-            },
-            {
-                "command": "metaGo.delete.softDelete",
-                "title": "metaGo: delete: softDelete"
-            }
-        ],
-        "keybindings": [
-            {
-                "command": "metaGo.input.cancel",
-                "key": "escape",
-                "when": "editorTextFocus && metaGoInput"
-            },
-            {
-                "command": "metaGo.gotoBefore",
-                "key": "ctrl+alt+;",
-                "when": "editorTextFocus",
-                "description": "goto the character and set the cursor before the character"
-            },
-            {
-                "command": "metaGo.goto",
-                "key": "alt+;",
-                "when": "editorTextFocus",
-                "description": "goto the character and set the cursor after the character"
-            },
-            {
-                "command": "metaGo.selection",
-                "key": "alt+shift+;",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.selectLineUp",
-                "key": "ctrl+shift+i",
-                "mac": "cmd+shift+i",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.selectLineDown",
-                "key": "ctrl+i",
-                "mac": "cmd+i",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.currentLineToCenter",
-                "key": "alt+m",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.currentLineToBottom",
-                "key": "alt+b",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.currentLineToTop",
-                "key": "alt+t",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.spaceBlockMoveUp",
-                "key": "alt+home",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.spaceBlockSelectUp",
-                "key": "alt+shift+home",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.spaceBlockMoveDown",
-                "key": "alt+end",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.spaceBlockSelectDown",
-                "key": "alt+shift+end",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.bookmark.toggle",
-                "key": "alt+'",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.bookmark.view",
-                "key": "alt+/",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.jumpToBracket",
-                "key": "ctrl+shift+\\",
-                "when": "editorTextFocus"
-            },
-            {
-                "command": "metaGo.delete.softDelete",
-                "key": "shift+Backspace",
-                "when": "editorTextFocus"
-            }
-        ],
-        "menus": {
-            "editor/context": [
-                {
-                    "command": "metaGo.bookmark.toggle",
-                    "group": "bookmarks"
-                }
-            ],
-            "editor/title": [
-                {
-                    "command": "metaGo.bookmark.view",
-                    "group": "bookmarks"
-                },
-                {
-                    "command": "metaGo.bookmark.clear",
-                    "group": "bookmarks"
-                }
-            ]
-        },
-        "configuration": {
-            "title": "metaseed metaGo",
-            "type": "object",
-            "properties": {
-                "metaGo.decoration.backgroundColor": {
-                    "type": "string",
-                    "default": "Chartreuse,yellow",
-                    "description": "one and two character decorator background color"
-                },
-                "metaGo.decoration.backgroundOpacity": {
-                    "type": "string",
-                    "default": "0.8"
-                },
-                "metaGo.decoration.borderColor": {
-                    "type": "string",
-                    "default": "#1e1e1e"
-                },
-                "metaGo.decoration.color": {
-                    "type": "string",
-                    "default": "blue"
-                },
-                "metaGo.decoration.width": {
-                    "type": "number",
-                    "default": 9
-                },
-                "metaGo.decoration.height": {
-                    "type": "number",
-                    "default": 15
-                },
-                "metaGo.decoration.fontSize": {
-                    "type": "number",
-                    "default": 13
-                },
-                "metaGo.decoration.x": {
-                    "type": "number",
-                    "default": 1
-                },
-                "metaGo.decoration.y": {
-                    "type": "number",
-                    "default": 12
-                },
-                "metaGo.decoration.fontWeight": {
-                    "type": "string",
-                    "default": "bold"
-                },
-                "metaGo.decoration.fontFamily": {
-                    "type": "string",
-                    "default": "Consolas"
-                },
-                "metaGo.decoration.upperCase": {
-                    "type": "boolean",
-                    "default": false
-                },
-                "metaGo.decoration.characters": {
-                    "type": "string",
-                    "default": "k, j, d, f, l, s, a, h, g, i, o, n, u, r, v, c, w, e, x, m, b, p, q, t, y, z"
-                },
-                "metaGo.jumper.findInSelection": {
-                    "type": "string",
-                    "default": "off"
-                },
-                "metaGo.jumper.targetIgnoreCase": {
-                    "type": "boolean",
-                    "default": true
-                },
-                "metaGo.jumper.timeout": {
-                    "type": "number",
-                    "default": "12",
-                    "description": "timeout value in seconds to cancel metaGo jumper commands."
-                },
-                "metaGo.jumper.findAllMode": {
-                    "type": "string",
-                    "default": "on",
-                    "description": "on: find all characters on viewable screen area; off: only search the first character of the words that are separated by chars configured in 'wordSeparatorPattern'"
-                },
-                "metaGo.jumper.wordSeparatorPattern": {
-                    "type": "string",
-                    "default": "[ ,-.{_(\"'<\\/[+]"
-                },
-                "metaGo.jumper.screenLineRange": {
-                    "type": "number",
-                    "default": 50,
-                    "description": "how many lines could be showed in one screen"
-                },
-                "metaGo.bookmark.saveBookmarksInProject": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Allow bookmarks to be saved (and restored) locally in the opened Project/Folder instead of VS Code"
-                },
-                "metaGo.bookmark.gutterIconPath": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Path to another image to be presented as Bookmark"
-                }
-            }
-        }
-    },
-    "scripts": {
-        "publish": "vsce publish minor",
-        "package": "vsce package",
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "typescript": "^2.2.2",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
-    }
+	"name": "metago",
+	"displayName": "MetaGo",
+	"description": "vscode cursor move and select; jump, navigation, goto, acejump",
+	"icon": "images/metago.png",
+	"version": "2.11.0",
+	"publisher": "metaseed",
+	"homepage": "https://github.com/metaseed/metaGo",
+	"license": "MIT",
+	"keywords": [
+		"jumpy",
+		"goto",
+		"navigation",
+		"EasyMotion",
+		"acejump, metaGo, center screen, focus screen, space jumper, shortcut"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/metaseed/metaGo.git"
+	},
+	"bugs": {
+		"url": "https://github.com/metaseed/metaGo/issues",
+		"email": "metaseed@gmail.com"
+	},
+	"engines": {
+		"vscode": "^1.8.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"*"
+	],
+	"main": "./out/src/extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "metaGo.goto",
+				"title": "metaGo: GoTo"
+			},
+			{
+				"command": "metaGo.selection",
+				"title": "metaGo: selection"
+			},
+			{
+				"command": "metaGo.gotoAfter",
+				"title": "metaGo: GoToAfter"
+			},
+			{
+				"command": "metaGo.gotoBefore",
+				"title": "metaGo: gotoBefore"
+			},
+			{
+				"command": "metaGo.selectLineUp",
+				"title": "metaGo: selectLineUp"
+			},
+			{
+				"command": "metaGo.selectLineDown",
+				"title": "metaGo: selectLineDown"
+			},
+			{
+				"command": "metaGo.currentLineToCenter",
+				"title": "metaGo: currentLineToCenter"
+			},
+			{
+				"command": "metaGo.currentLineToTop",
+				"title": "metaGo: currentLineToTop"
+			},
+			{
+				"command": "metaGo.spaceBlockMoveUp",
+				"title": "metaGo: spaceBlockMoveUp"
+			},
+			{
+				"command": "metaGo.spaceBlockSelectUp",
+				"title": "metaGo: spaceBlockSelectUp"
+			},
+			{
+				"command": "metaGo.spaceBlockMoveDown",
+				"title": "metaGo: spaceBlockMoveDown"
+			},
+			{
+				"command": "metaGo.spaceBlockSelectDown",
+				"title": "metaGo: spaceBlockSelectDown"
+			},
+			{
+				"command": "metaGo.bookmark.toggle",
+				"title": "metaGo: bookmark: Toggle"
+			},
+			{
+				"command": "metaGo.bookmark.view",
+				"title": "metaGo: bookmark: View"
+			},
+			{
+				"command": "metaGo.bookmark.clear",
+				"title": "metaGo: bookmark: Clear"
+			},
+			{
+				"command": "metaGo.delete.softDelete",
+				"title": "metaGo: delete: softDelete"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "metaGo.input.cancel",
+				"key": "escape",
+				"when": "editorTextFocus && metaGoInput"
+			},
+			{
+				"command": "metaGo.gotoBefore",
+				"key": "ctrl+alt+;",
+				"when": "editorTextFocus",
+				"description": "goto the character and set the cursor before the character"
+			},
+			{
+				"command": "metaGo.goto",
+				"key": "alt+;",
+				"when": "editorTextFocus",
+				"description": "goto the character and set the cursor after the character"
+			},
+			{
+				"command": "metaGo.selection",
+				"key": "alt+shift+;",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.selectLineUp",
+				"key": "ctrl+shift+i",
+				"mac": "cmd+shift+i",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.selectLineDown",
+				"key": "ctrl+i",
+				"mac": "cmd+i",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.currentLineToCenter",
+				"key": "alt+m",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.currentLineToBottom",
+				"key": "alt+b",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.currentLineToTop",
+				"key": "alt+t",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.spaceBlockMoveUp",
+				"key": "alt+home",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.spaceBlockSelectUp",
+				"key": "alt+shift+home",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.spaceBlockMoveDown",
+				"key": "alt+end",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.spaceBlockSelectDown",
+				"key": "alt+shift+end",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.bookmark.toggle",
+				"key": "alt+'",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.bookmark.view",
+				"key": "alt+/",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.jumpToBracket",
+				"key": "ctrl+shift+\\",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "metaGo.delete.softDelete",
+				"key": "shift+Backspace",
+				"when": "editorTextFocus"
+			}
+		],
+		"menus": {
+			"editor/context": [
+				{
+					"command": "metaGo.bookmark.toggle",
+					"group": "bookmarks"
+				}
+			],
+			"editor/title": [
+				{
+					"command": "metaGo.bookmark.view",
+					"group": "bookmarks"
+				},
+				{
+					"command": "metaGo.bookmark.clear",
+					"group": "bookmarks"
+				}
+			]
+		},
+		"configuration": {
+			"title": "metaseed metaGo",
+			"type": "object",
+			"properties": {
+				"metaGo.decoration.useTextBasedDecorations": {
+					"type": "boolean",
+					"default": false,
+					"description": "Only enable if editor decorations are not showing. Use text-based decorations in editors instead of SVG based. Supports fewer customisations but may be more robust."
+				},
+				"metaGo.decoration.backgroundColor": {
+					"type": "string",
+					"default": "chartreuse,yellow",
+					"description": "one and two character decorator background color"
+				},
+				"metaGo.decoration.backgroundOpacity": {
+					"type": "string",
+					"default": "0.8"
+				},
+				"metaGo.decoration.borderColor": {
+					"type": "string",
+					"default": "#1e1e1e"
+				},
+				"metaGo.decoration.color": {
+					"type": "string",
+					"default": "blue"
+				},
+				"metaGo.decoration.width": {
+					"type": "number",
+					"default": 9
+				},
+				"metaGo.decoration.height": {
+					"type": "number",
+					"default": 15
+				},
+				"metaGo.decoration.fontSize": {
+					"type": "number",
+					"default": 13
+				},
+				"metaGo.decoration.x": {
+					"type": "number",
+					"default": 1
+				},
+				"metaGo.decoration.y": {
+					"type": "number",
+					"default": 12
+				},
+				"metaGo.decoration.fontWeight": {
+					"type": "string",
+					"default": "bold"
+				},
+				"metaGo.decoration.fontFamily": {
+					"type": "string",
+					"default": "Consolas"
+				},
+				"metaGo.decoration.upperCase": {
+					"type": "boolean",
+					"default": false
+				},
+				"metaGo.decoration.characters": {
+					"type": "string",
+					"default": "k, j, d, f, l, s, a, h, g, i, o, n, u, r, v, c, w, e, x, m, b, p, q, t, y, z"
+				},
+				"metaGo.jumper.findInSelection": {
+					"type": "string",
+					"default": "off"
+				},
+				"metaGo.jumper.targetIgnoreCase": {
+					"type": "boolean",
+					"default": true
+				},
+				"metaGo.jumper.timeout": {
+					"type": "number",
+					"default": "12",
+					"description": "timeout value in seconds to cancel metaGo jumper commands."
+				},
+				"metaGo.jumper.findAllMode": {
+					"type": "string",
+					"default": "on",
+					"description": "on: find all characters on viewable screen area; off: only search the first character of the words that are separated by chars configured in 'wordSeparatorPattern'"
+				},
+				"metaGo.jumper.wordSeparatorPattern": {
+					"type": "string",
+					"default": "[ ,-.{_(\"'<\\/[+]"
+				},
+				"metaGo.jumper.screenLineRange": {
+					"type": "number",
+					"default": 50,
+					"description": "how many lines could be showed in one screen"
+				},
+				"metaGo.bookmark.saveBookmarksInProject": {
+					"type": "boolean",
+					"default": false,
+					"description": "Allow bookmarks to be saved (and restored) locally in the opened Project/Folder instead of VS Code"
+				},
+				"metaGo.bookmark.gutterIconPath": {
+					"type": "string",
+					"default": "",
+					"description": "Path to another image to be presented as Bookmark"
+				}
+			}
+		}
+	},
+	"scripts": {
+		"publish": "vsce publish minor",
+		"package": "vsce package",
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install",
+		"test": "node ./node_modules/vscode/bin/test"
+	},
+	"devDependencies": {
+		"typescript": "^2.2.2",
+		"vscode": "^1.0.0",
+		"mocha": "^2.3.3",
+		"@types/node": "^6.0.40",
+		"@types/mocha": "^2.2.32"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "metago",
+	"name": "metagogo",
 	"displayName": "MetaGo",
 	"description": "vscode cursor move and select; jump, navigation, goto, acejump",
 	"icon": "images/metago.png",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "metagogo",
-	"displayName": "MetaGo",
+	"displayName": "MetaGoGo",
 	"description": "vscode cursor move and select; jump, navigation, goto, acejump",
 	"icon": "images/metago.png",
 	"version": "2.11.0",
 	"publisher": "metaseed",
-	"homepage": "https://github.com/metaseed/metaGo",
+	"homepage": "https://github.com/nicchristeller/metaGo",
 	"license": "MIT",
 	"keywords": [
 		"jumpy",
@@ -16,7 +16,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/metaseed/metaGo.git"
+		"url": "https://github.com/nicchristeller/metaGo.git"
 	},
 	"bugs": {
 		"url": "https://github.com/metaseed/metaGo/issues",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
 			"properties": {
 				"metaGo.decoration.useTextBasedDecorations": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "Only enable if editor decorations are not showing. Use text-based decorations in editors instead of SVG based. Supports fewer customisations but may be more robust."
 				},
 				"metaGo.decoration.backgroundColor": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "vscode cursor move and select; jump, navigation, goto, acejump",
 	"icon": "images/metago.png",
 	"version": "2.11.0",
-	"publisher": "metaseed",
+	"publisher": "metagogo",
 	"homepage": "https://github.com/nicchristeller/metaGo",
 	"license": "MIT",
 	"keywords": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,73 +2,77 @@ import * as vscode from "vscode";
 import { BookmarkConfig } from './bookmark/config';
 
 export class Config {
-    decoration: DecoratorConfig = new DecoratorConfig();
-    jumper: FinderConfig = new FinderConfig();
-    bookmark = new BookmarkConfig();
+	decoration: DecoratorConfig = new DecoratorConfig();
+	jumper: FinderConfig = new FinderConfig();
+	bookmark = new BookmarkConfig();
 
-    loadConfig = () => {
-        try {
-            this.bookmark.loadConfig();
-            let config = vscode.workspace.getConfiguration("metaGo");
+	loadConfig = () => {
+		try {
+			this.bookmark.loadConfig();
+			let config = vscode.workspace.getConfiguration("metaGo");
 
-            this.decoration.bgColor = config.get<string>("decoration.backgroundColor", this.decoration.bgColor);
-            this.decoration.bgOpacity = config.get<string>("decoration.backgroundOpacity", this.decoration.bgOpacity);
+			this.decoration.useTextBasedDecorations = config.get<boolean>("decoration.useTextBasedDecorations", this.decoration.useTextBasedDecorations);
 
-            this.decoration.color = config.get<string>("decoration.color", this.decoration.color);
-            this.decoration.borderColor = config.get<string>("decoration.borderColor", this.decoration.borderColor);
+			this.decoration.bgColor = config.get<string>("decoration.backgroundColor", this.decoration.bgColor);
+			this.decoration.bgOpacity = config.get<string>("decoration.backgroundOpacity", this.decoration.bgOpacity);
 
-            this.decoration.width = config.get<number>("decoration.width", this.decoration.width);
-            this.decoration.height = config.get<number>("decoration.height", this.decoration.height);
+			this.decoration.color = config.get<string>("decoration.color", this.decoration.color);
+			this.decoration.borderColor = config.get<string>("decoration.borderColor", this.decoration.borderColor);
 
-            this.decoration.x = config.get<number>("decoration.x", this.decoration.x);
-            this.decoration.y = config.get<number>("decoration.y", this.decoration.y);
+			this.decoration.width = config.get<number>("decoration.width", this.decoration.width);
+			this.decoration.height = config.get<number>("decoration.height", this.decoration.height);
 
-            this.decoration.fontSize = config.get<number>("decoration.fontSize", this.decoration.fontSize);
-            this.decoration.fontWeight = config.get<string>("decoration.fontWeight", this.decoration.fontWeight);
-            this.decoration.fontFamily = config.get<string>("decoration.fontFamily", this.decoration.fontFamily);
-            this.decoration.upperCase = config.get<boolean>("decoration.upperCase", this.decoration.upperCase);
-            this.jumper.characters = config.get<string>("decoration.characters", "k, j, d, f, l, s, a, h, g, i, o, n, u, r, v, c, w, e, x, m, b, p, q, t, y, z").split(/[\s,]+/);
+			this.decoration.x = config.get<number>("decoration.x", this.decoration.x);
+			this.decoration.y = config.get<number>("decoration.y", this.decoration.y);
 
-            this.jumper.findAllMode = config.get<string>("jumper.findAllMode", this.jumper.findAllMode);
-            this.jumper.findInSelection = config.get<string>("jumper.findInSelection", this.jumper.findInSelection);
-            this.jumper.wordSeparatorPattern = config.get<string>("jumper.wordSeparatorPattern", this.jumper.wordSeparatorPattern);
-            this.jumper.range = config.get<number>("jumper.screenLineRange", this.jumper.range);
-            this.jumper.targetIgnoreCase = config.get<boolean>("jumper.targetIgnoreCase", this.jumper.targetIgnoreCase);
-            let timeout = config.get<number>("jumper.timeout", this.jumper.timeout);
-            this.jumper.timeout = isNaN(timeout) ? 12000 : timeout * 1000;
-        }
-        catch (e) {
-            vscode.window.showErrorMessage('metaGo: please double check your metaGo config->' + e);
-        }
-    }
+			this.decoration.fontSize = config.get<number>("decoration.fontSize", this.decoration.fontSize);
+			this.decoration.fontWeight = config.get<string>("decoration.fontWeight", this.decoration.fontWeight);
+			this.decoration.fontFamily = config.get<string>("decoration.fontFamily", this.decoration.fontFamily);
+			this.decoration.upperCase = config.get<boolean>("decoration.upperCase", this.decoration.upperCase);
+			this.jumper.characters = config.get<string>("decoration.characters", "k, j, d, f, l, s, a, h, g, i, o, n, u, r, v, c, w, e, x, m, b, p, q, t, y, z").split(/[\s,]+/);
+
+			this.jumper.findAllMode = config.get<string>("jumper.findAllMode", this.jumper.findAllMode);
+			this.jumper.findInSelection = config.get<string>("jumper.findInSelection", this.jumper.findInSelection);
+			this.jumper.wordSeparatorPattern = config.get<string>("jumper.wordSeparatorPattern", this.jumper.wordSeparatorPattern);
+			this.jumper.range = config.get<number>("jumper.screenLineRange", this.jumper.range);
+			this.jumper.targetIgnoreCase = config.get<boolean>("jumper.targetIgnoreCase", this.jumper.targetIgnoreCase);
+			let timeout = config.get<number>("jumper.timeout", this.jumper.timeout);
+			this.jumper.timeout = isNaN(timeout) ? 12000 : timeout * 1000;
+		}
+		catch (e) {
+			vscode.window.showErrorMessage('metaGo: please double check your metaGo config->' + e);
+		}
+	}
 
 }
 
 class DecoratorConfig {
-    bgOpacity: string = '0.88';
-    bgColor: string = "lime,yellow";
-    color: string = "black";
-    borderColor: string = "black";
+	useTextBasedDecorations: boolean = false;
 
-    width: number = 12;
-    height: number = 14;
+	bgOpacity: string = '0.88';
+	bgColor: string = "lime,yellow";
+	color: string = "black";
+	borderColor: string = "black";
 
-    x: number = 2;
-    y: number = 12;
+	width: number = 12;
+	height: number = 14;
 
-    fontSize: number = 14;
-    fontWeight: string = "normal";
-    fontFamily: string = "Consolas";
+	x: number = 2;
+	y: number = 12;
 
-    upperCase: boolean = false;
+	fontSize: number = 14;
+	fontWeight: string = "normal";
+	fontFamily: string = "Consolas";
+
+	upperCase: boolean = false;
 }
 
 class FinderConfig {
-    characters: string[] = ["k", "j", "d", "f", "l", "s", "a", "h", "g", "i", "o", "n", "u", "r", "v", "c", "w", "e", "x", "m", "b", "p", "q", "t", "y", "z"];
-    findAllMode: string = 'on';
-    findInSelection: string = 'off';
-    wordSeparatorPattern: string = "[ ,-.{_(\"'<\\/[+]";
-    range: number = 50;
-    targetIgnoreCase: boolean = true;
-    timeout: number = 12000;
+	characters: string[] = ["k", "j", "d", "f", "l", "s", "a", "h", "g", "i", "o", "n", "u", "r", "v", "c", "w", "e", "x", "m", "b", "p", "q", "t", "y", "z"];
+	findAllMode: string = 'on';
+	findInSelection: string = 'off';
+	wordSeparatorPattern: string = "[ ,-.{_(\"'<\\/[+]";
+	range: number = 50;
+	targetIgnoreCase: boolean = true;
+	timeout: number = 12000;
 }

--- a/src/metajumper/decoration.ts
+++ b/src/metajumper/decoration.ts
@@ -3,128 +3,156 @@ import { DecorationModel } from './decoration-model';
 import { Config } from '../config';
 
 export class Decorator {
-    private config: Config;
-    private cache: { [index: string]: vscode.Uri };
-    private decorations: { [index: number]: vscode.TextEditorDecorationType } = {};
-    public charDecorationType;
+	private config: Config;
+	private cache: { [index: string]: vscode.ThemableDecorationAttachmentRenderOptions };
+	private decorations: { [index: number]: vscode.TextEditorDecorationType } = {};
+	public charDecorationType;
 
-    initialize = (config: Config) => {
-        this.config = config;
-        this.updateCache();
-        this.charDecorationType = vscode.window.createTextEditorDecorationType({
-            backgroundColor: 'rgba(0,255,0,0.3)',
-            borderWidth: '2px',
-            borderStyle: 'solid',
-            light: {
-                // this color will be used in light color themes
-                borderColor: 'rgba(0,255,0,0.3)'
-            },
-            dark: {
-                // this color will be used in dark color themes
-                borderColor: 'rgba(0,255,0,0.3)'
-            }
-        });
-    }
+	initialize = (config: Config) => {
+		this.config = config;
+		this.updateCache();
+		this.charDecorationType = vscode.window.createTextEditorDecorationType({
+			backgroundColor: 'rgba(0,255,0,0.3)',
+			borderWidth: '2px',
+			borderStyle: 'solid',
+			light: {
+				// this color will be used in light color themes
+				borderColor: 'rgba(0,255,0,0.3)'
+			},
+			dark: {
+				// this color will be used in dark color themes
+				borderColor: 'rgba(0,255,0,0.3)'
+			}
+		});
+	}
 
-    addCommandIndicator = (editor: vscode.TextEditor) => {
-        let line = editor.selection.anchor.line;
-        let char = editor.selection.anchor.character;
-        let option = [new vscode.Range(line, char, line, char)];
-        editor.setDecorations(this.charDecorationType, option);
-    }
+	addCommandIndicator = (editor: vscode.TextEditor) => {
+		let line = editor.selection.anchor.line;
+		let char = editor.selection.anchor.character;
+		let option = [new vscode.Range(line, char, line, char)];
+		editor.setDecorations(this.charDecorationType, option);
+	}
 
-    removeCommandIndicator = (editor: vscode.TextEditor) => {
-        let locations: vscode.Range[] = [];
-        vscode.window.activeTextEditor.setDecorations(this.charDecorationType, locations);
-    }
+	removeCommandIndicator = (editor: vscode.TextEditor) => {
+		let locations: vscode.Range[] = [];
+		vscode.window.activeTextEditor.setDecorations(this.charDecorationType, locations);
+	}
 
-    addDecorations = (editor: vscode.TextEditor, decorationModel: DecorationModel[]) => {
-        let decorationType = this.createTextEditorDecorationType(1);
-        let decorationType2 = this.createTextEditorDecorationType(2);
+	addDecorations = (editor: vscode.TextEditor, decorationModel: DecorationModel[]) => {
+		let decorationType = this.createTextEditorDecorationType(1);
+		let decorationType2 = this.createTextEditorDecorationType(2);
 
-        let options = [];
-        let options2 = [];
-        decorationModel.forEach((model) => {
-            let code = model.code;
-            let len = code.length;
+		let options = [];
+		let options2 = [];
+		decorationModel.forEach((model) => {
+			let code = model.code;
+			let len = code.length;
 
-            let option: any;
-            if (len === 1) {
-                option = this.createDecorationOptions(null, model.line, model.character + 1, model.character + 1, code);
-                options.push(option);
-            }
-            else {
-                option = this.createDecorationOptions(null, model.line, model.character + 1, model.character + len, code);
-                options2.push(option);
-            }
-        })
-        editor.setDecorations(decorationType, options);
-        editor.setDecorations(decorationType2, options2);
-    }
+			let option: any;
+			if (len === 1) {
+				option = this.createDecorationOptions(null, model.line, model.character + 1, model.character + 1, code);
+				options.push(option);
+			}
+			else {
+				option = this.createDecorationOptions(null, model.line, model.character + 1, model.character + len, code);
+				options2.push(option);
+			}
+		});
 
-    removeDecorations = (editor: vscode.TextEditor) => {
-        for (var dec in this.decorations) {
-            if (this.decorations[dec] === null) continue;
-            editor.setDecorations(this.decorations[dec], []);
-            this.decorations[dec].dispose();
-            this.decorations[dec] = null;
-        }
-    }
+		editor.setDecorations(decorationType, options);
+		editor.setDecorations(decorationType2, options2);
+	}
 
-    private createTextEditorDecorationType = (charsToOffset: number) => {
-        let decorationType = this.decorations[charsToOffset];
-        if (decorationType) return decorationType;
-        decorationType = vscode.window.createTextEditorDecorationType({
-            after: {
-                margin: `0 0 0 ${charsToOffset * (-this.config.decoration.width)}px`,
-                height: `${this.config.decoration.height}px`,
-                width: `${charsToOffset * this.config.decoration.width}px`
-            }
-        });
-        this.decorations[charsToOffset] = decorationType;
-        return decorationType;
-    }
+	removeDecorations = (editor: vscode.TextEditor) => {
+		for (var dec in this.decorations) {
+			if (this.decorations[dec] === null) continue;
+			editor.setDecorations(this.decorations[dec], []);
+			this.decorations[dec].dispose();
+			this.decorations[dec] = null;
+		}
+	}
 
-    private createDecorationOptions = (context: vscode.ExtensionContext, line: number, startCharacter: number, endCharacter: number, code: string): vscode.DecorationOptions => {
-        return {
-            range: new vscode.Range(line, startCharacter, line, endCharacter),
-            renderOptions: {
-                dark: {
-                    after: {
-                        contentIconPath: this.getUri(code)
-                    }
-                },
-                light: {
-                    after: {
-                        contentIconPath: this.getUri(code)
-                    }
-                }
-            }
-        };
-    }
+	private createTextEditorDecorationType = (charsToOffset: number) => {
+		let decorationType = this.decorations[charsToOffset];
+		if (decorationType) return decorationType;
+		decorationType = vscode.window.createTextEditorDecorationType({
+			after: {
+				margin: `0 0 0 ${charsToOffset * (-this.config.decoration.width)}px`,
+				height: `${this.config.decoration.height}px`,
+				width: `${charsToOffset * this.config.decoration.width}px`
+			}
+		});
+		this.decorations[charsToOffset] = decorationType;
+		return decorationType;
+	}
 
-    private getUri = (code: string) => {
-        if (this.cache[code] != undefined)
-            return this.cache[code];
-        this.cache[code] = this.buildUri(code);
-        return this.cache[code];
-    }
+	private createDecorationOptions = (context: vscode.ExtensionContext, line: number, startCharacter: number, endCharacter: number, code: string): vscode.DecorationOptions => {
+		const renderOptions = this.getAfterRenderOptions(code);
+		return {
+			range: new vscode.Range(line, startCharacter, line, endCharacter),
+			renderOptions: {
+				dark: {
+					after: renderOptions,
+				},
+				light: {
+					after: renderOptions,
+				},
+			}
+		};
+	}
 
-    private updateCache = () => {
-        this.cache = {};
-        this.config.jumper.characters
-            .forEach(code => this.cache[code] = this.buildUri(code))
-    }
+	private getAfterRenderOptions = (code: string) => {
+		if (this.cache[code] !== undefined)
+			return this.cache[code];
+		this.cache[code] = this.buildAfterRenderOptions(code);
+		return this.cache[code];
+	}
 
-    private buildUri = (code: string) => {
-        let cf = this.config.decoration;
-        let key = this.config.decoration.upperCase ? code.toUpperCase() : code.toLowerCase();
-        let width = code.length * cf.width;
-        let colors = cf.bgColor.split(',');
-        let bgColor = colors[(code.length - 1) % colors.length];
-        let svg =
-            `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${cf.height}" height="${cf.height}" width="${width}"><rect width="${width}" height="${cf.height}" rx="2" ry="3" style="fill: ${bgColor};fill-opacity:${cf.bgOpacity};stroke:${cf.borderColor};stroke-opacity:${cf.bgOpacity};"/><text font-family="${cf.fontFamily}" font-weight="${cf.fontWeight}" font-size="${cf.fontSize}px" style="fill:${cf.color}" x="${cf.x}" y="${cf.y}">${key}</text></svg>`;
-        return vscode.Uri.parse(svg);
-    }
+	private updateCache = () => {
+		this.cache = {};
+		this.config.jumper.characters
+			.forEach(code => this.cache[code] = this.buildAfterRenderOptions(code))
+	}
+
+	private buildAfterRenderOptions = (code: string) => {
+		return this.config.decoration.useTextBasedDecorations
+			? this.buildAfterRenderOptionsText(code)
+			: this.buildAfterRenderOptionsSvg(code)
+			;
+	}
+
+	private buildAfterRenderOptionsText = (code: string) => {
+		let cf = this.config.decoration;
+		let key = cf.upperCase ? code.toUpperCase() : code.toLowerCase();
+
+		const knownColors = {
+			chartreuse: `rgba(127,255,0,${cf.bgOpacity})`,
+			yellow: `rgba(255,255,0,${cf.bgOpacity})`,
+		};
+
+		let colors = cf.bgColor.split(',');
+		let bgColor = colors[(code.length - 1) % colors.length];
+		bgColor = knownColors[bgColor] || bgColor;
+
+		return {
+			contentText: key,
+			backgroundColor: bgColor,
+			fontWeight: cf.fontWeight,
+			color: cf.color,
+		};
+	}
+
+	private buildAfterRenderOptionsSvg = (code: string) => {
+		let cf = this.config.decoration;
+		let key = this.config.decoration.upperCase ? code.toUpperCase() : code.toLowerCase();
+		let width = code.length * cf.width;
+		let colors = cf.bgColor.split(',');
+		let bgColor = colors[(code.length - 1) % colors.length];
+		let svg =
+			`data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${cf.height}" height="${cf.height}" width="${width}"><rect width="${width}" height="${cf.height}" rx="2" ry="3" style="fill: ${bgColor};fill-opacity:${cf.bgOpacity};stroke:${cf.borderColor};stroke-opacity:${cf.bgOpacity};"/><text font-family="${cf.fontFamily}" font-weight="${cf.fontWeight}" font-size="${cf.fontSize}px" style="fill:${cf.color}" x="${cf.x}" y="${cf.y}">${key}</text></svg>`;
+		return {
+			contentIconPath: vscode.Uri.parse(svg)
+		};
+	}
 
 }


### PR DESCRIPTION
Added the setting `metaGo.decoration.useTextBasedDecorations` that will use `contentText` instead of `contentIconPath` when creating editor decorations.

Investigating #28, I am unsure why the decorations have disappeared in the newest version of VSCode. This is a workaround which is functionally identical for users with near default settings. 