### PR TITLE
Visual Studio Marketplace Badge Service URL Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Version](https://vsmarketplacebadge.apphb.com/version/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
-[![Ratings](https://vsmarketplacebadge.apphb.com/rating/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
+[![Version](https://vsmarketplacebadges.dev/version/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
+[![Installs](https://vsmarketplacebadges.dev/installs/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
+[![Ratings](https://vsmarketplacebadges.dev/rating/metaseed.metago.svg)](https://marketplace.visualstudio.com/items?itemName=metaseed.metago)
 [![](https://img.shields.io/badge/TWITTER-%40metaseed-blue.svg?logo=twitter&style=flat)](https://twitter.com/metaseed)
 [![](https://img.shields.io/badge/gitter-join_chat-1dce73.svg?style=flat&logo=gitter-white)](https://gitter.im/vscode-metago/community)
 ---


### PR DESCRIPTION
VSMarketplaceBadges is migrating to a new platform, please change the URL.
https://vsmarketplacebadge.apphb.com -> https://vsmarketplacebadges.dev
https://github.com/cssho/VSMarketplaceBadge -> https://github.com/cssho/VSMarketplaceBadges